### PR TITLE
Fix Svelte 5 Runes

### DIFF
--- a/docs/src/content/docs/es/svelte/guides/verticallist.mdx
+++ b/docs/src/content/docs/es/svelte/guides/verticallist.mdx
@@ -14,7 +14,7 @@ Primero, vamos a crear una lista de números:
 export const listOfNumbers = `<script setup lang="ts">
 import { useDragAndDrop } from "fluid-dnd/svelte";
 
-const list = state([1, 2, 3]);
+const list = $state([1, 2, 3]);
 const [ parent ] = useDragAndDrop(list);
 
 </script>`;

--- a/docs/src/content/docs/svelte/guides/verticallist.mdx
+++ b/docs/src/content/docs/svelte/guides/verticallist.mdx
@@ -14,7 +14,7 @@ First, we're going to create a list of numbers:
 export const listOfNumbers = `<script setup lang="ts">
 import { useDragAndDrop } from "fluid-dnd/vue";
 
-const list = state([1, 2, 3]);
+const list = $state([1, 2, 3]);
 const [ parent ] = useDragAndDrop(list);
 
 </script>`;


### PR DESCRIPTION
Two places in the docs, the sample code used Svelte 5 runes incorrectly. The corrected styntax is `$state` without the `$` the example code from the docs does not work.